### PR TITLE
configure.ac: make NDPI_API_VERSION to be fixed and equal to 5716.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,6 +69,10 @@ if test -d ".git" || test -f ".git" ; then :
      B=`git log src/include/ndpi_protocol_ids.h|wc -l`
      C=`git log src/include/ndpi_api.h.in|wc -l`
      NDPI_API_VERSION=$((A+B+C))
+     # imt uses binary version of pf_ring_ft and cannot change it.
+     # imt uses ndpi with additional changes that touch protocol ids.
+     # we hard code here api version for 4.2-stable ndpi.
+     NDPI_API_VERSION=5716
 else
      GIT_RELEASE="${PACKAGE_VERSION}"
      GIT_DATE=`date -u -r CHANGELOG.md`


### PR DESCRIPTION
This is the api version hardcoded inside pf_ring_ft binaries for
8.0-stable.

Signed-off-by: Vitaliy Ivanov <vitaliyi@interfacemasters.com>